### PR TITLE
[Fix] 메일 조회할 때 메일 내용 파싱 과정 수정 및 응답 데이터 형식 일괄 수정

### DIFF
--- a/src/main/java/com/example/capstoneback/Controller/EmailController.java
+++ b/src/main/java/com/example/capstoneback/Controller/EmailController.java
@@ -1,7 +1,6 @@
 package com.example.capstoneback.Controller;
 
 import com.example.capstoneback.DTO.*;
-import com.example.capstoneback.Service.EmailService;
 import com.example.capstoneback.Service.GmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,26 +20,26 @@ public class EmailController {
     private final GmailService gmailService;
 
     @GetMapping("/mails/receive")
-    public ResponseEntity<List<ReceivedEmailResponseDTO>> getReceivedEmails(Authentication authentication) throws IOException {
-        List<ReceivedEmailResponseDTO> responseDTO = gmailService.getReceivedGmail(authentication);
+    public ResponseEntity<Map<String, Object>> getReceivedEmails(@RequestParam(name = "pageToken", required = false) String pageToken, Authentication authentication) throws IOException {
+        Map<String, Object> responseDTO = gmailService.getReceivedGmail(pageToken, authentication);
         return ResponseEntity.ok(responseDTO);
     }
 
     @GetMapping("/mails/send")
-    public ResponseEntity<List<SentEmailResponseDTO>> getSentEmails(Authentication authentication) throws IOException {
-        List<SentEmailResponseDTO> responseDTO = gmailService.getSentGmail(authentication);
+    public ResponseEntity<Map<String, Object>> getSentEmails(@RequestParam(name = "pageToken", required = false) String pageToken,Authentication authentication) throws IOException {
+        Map<String, Object> responseDTO = gmailService.getSentGmail(pageToken, authentication);
         return ResponseEntity.ok(responseDTO);
     }
 
     @GetMapping("/mails/self")
-    public ResponseEntity<List<SelfEmailResponseDTO>> getSelfEmail(Authentication authentication) throws IOException {
-        List<SelfEmailResponseDTO> responseDTO = gmailService.getSelfGmail(authentication);
+    public ResponseEntity<Map<String, Object>> getSelfEmail(@RequestParam(name = "pageToken", required = false) String pageToken,Authentication authentication) throws IOException {
+        Map<String, Object> responseDTO = gmailService.getSelfGmail(pageToken, authentication);
         return ResponseEntity.ok(responseDTO);
     }
 
     @GetMapping("/mails/important")
-    public ResponseEntity<List<ImportantEmailResponseDTO>> getImportantEmails(Authentication authentication) throws IOException {
-        List<ImportantEmailResponseDTO> responseDTO = gmailService.getImportantGmail(authentication);
+    public ResponseEntity<Map<String, Object>> getImportantEmails(@RequestParam(name = "pageToken", required = false) String pageToken, Authentication authentication) throws IOException {
+        Map<String, Object> responseDTO = gmailService.getImportantGmail(pageToken, authentication);
         return ResponseEntity.ok(responseDTO);
     }
 
@@ -51,8 +50,8 @@ public class EmailController {
 //    }
 
     @GetMapping("/mails/draft")
-    public ResponseEntity<List<DraftEmailResponseDTO>> getDraftEmails(Authentication authentication) throws IOException {
-        List<DraftEmailResponseDTO> responseDTO = gmailService.getDraftGmail(authentication);
+    public ResponseEntity<Map<String, Object>> getDraftEmails(@RequestParam(name = "pageToken", required = false) String pageToken, Authentication authentication) throws IOException {
+        Map<String, Object> responseDTO = gmailService.getDraftGmail(pageToken, authentication);
         return ResponseEntity.ok(responseDTO);
     }
 
@@ -63,14 +62,14 @@ public class EmailController {
 //    }
 
     @GetMapping("/mails/spam")
-    public ResponseEntity<List<SpamEmailResponseDTO>> getSpamEmails(Authentication authentication) throws IOException {
-        List<SpamEmailResponseDTO> responseDTO = gmailService.getSpamGmail(authentication);
+    public ResponseEntity<Map<String, Object>> getSpamEmails(@RequestParam(name = "pageToken", required = false) String pageToken, Authentication authentication) throws IOException {
+        Map<String, Object> responseDTO = gmailService.getSpamGmail(pageToken, authentication);
         return ResponseEntity.ok(responseDTO);
     }
 
     @PostMapping("/mails/search/userEmail")
-    public ResponseEntity<List<ImportantEmailResponseDTO>> searchGmailsByUserEmail(@RequestBody SearchGmailsByUserEmailRequestDTO requestDTO, Authentication authentication) throws IOException {
-        List<ImportantEmailResponseDTO> responseDTO = gmailService.searchGmailsByUserEmail(requestDTO, authentication);
+    public ResponseEntity<Map<String, Object>> searchGmailsByUserEmail(@RequestBody SearchGmailsByUserEmailRequestDTO requestDTO, @RequestParam(name = "pageToken", required = false) String pageToken, Authentication authentication) throws IOException {
+        Map<String, Object> responseDTO = gmailService.searchGmailsByUserEmail(requestDTO, pageToken, authentication);
         return ResponseEntity.ok(responseDTO);
     }
 

--- a/src/main/java/com/example/capstoneback/DTO/UserInfoDTO.java
+++ b/src/main/java/com/example/capstoneback/DTO/UserInfoDTO.java
@@ -23,6 +23,9 @@ public class UserInfoDTO {
         @NotNull(message = "학번을 입력해주세요.")
         @Positive(message = "양수를 입력해주세요.")
         private Integer studentNum;
+
+        @NotNull(message = "학생 이름을 입력해주세요.")
+        private String studentName;
     }
 
     @Getter

--- a/src/main/java/com/example/capstoneback/Entity/User.java
+++ b/src/main/java/com/example/capstoneback/Entity/User.java
@@ -34,6 +34,7 @@ public class User {
     private String schoolName;
     private String studentDepartment;
     private Integer studentNum;
+    private String studentName;
 
     //직장인 추가정보
     private String workerDepartment;
@@ -75,10 +76,11 @@ public class User {
     }
 
 
-    public void updateStudentInfo(String schoolName, String studentDepartment, Integer studentNum){
+    public void updateStudentInfo(String schoolName, String studentDepartment, Integer studentNum, String studentName){
         this.schoolName = schoolName;
         this.studentDepartment = studentDepartment;
         this.studentNum = studentNum;
+        this.studentName = studentName;
     }
 
     public void updateWorkerInfo(String workerDepartment, String company, String position){

--- a/src/main/java/com/example/capstoneback/Service/GmailService.java
+++ b/src/main/java/com/example/capstoneback/Service/GmailService.java
@@ -179,32 +179,45 @@ public class GmailService {
 //        }
 //    }
 
-    public List<ReceivedEmailResponseDTO> getReceivedGmail(Authentication auth) throws IOException {
-        return getEmailsByLabel(auth, "INBOX", ReceivedEmailResponseDTO.class);
+    public Map<String, Object> getReceivedGmail(String pageToken, Authentication auth) throws IOException {
+        return getEmailsByLabel(pageToken, auth, "INBOX", ReceivedEmailResponseDTO.class);
     }
 
-    public List<SentEmailResponseDTO> getSentGmail(Authentication auth) throws IOException {
-        return getEmailsByLabel(auth, "SENT", SentEmailResponseDTO.class);
+    public Map<String, Object> getSentGmail(String pageToken, Authentication auth) throws IOException {
+        return getEmailsByLabel(pageToken, auth, "SENT", SentEmailResponseDTO.class);
     }
 
-    public List<ImportantEmailResponseDTO> getImportantGmail(Authentication auth) throws IOException {
-        return getEmailsByLabel(auth, "STARRED", ImportantEmailResponseDTO.class);
+    public Map<String, Object> getImportantGmail(String pageToken, Authentication auth) throws IOException {
+        return getEmailsByLabel(pageToken, auth, "STARRED", ImportantEmailResponseDTO.class);
     }
 
-    public List<SpamEmailResponseDTO> getSpamGmail(Authentication auth) throws IOException {
-        return getEmailsByLabel(auth, "SPAM", SpamEmailResponseDTO.class);
+    public Map<String, Object> getSpamGmail(String pageToken, Authentication auth) throws IOException {
+        return getEmailsByLabel(pageToken, auth, "SPAM", SpamEmailResponseDTO.class);
     }
 
-    public List<DraftEmailResponseDTO> getDraftGmail(Authentication auth) throws IOException {
+    public Map<String, Object> getDraftGmail(String pageToken, Authentication auth) throws IOException {
         User user = getUser(auth);
         Gmail gmail = getGmailService(user);
+        ListDraftsResponse draftsResponse;
 
-        ListDraftsResponse draftsResponse = gmail.users().drafts()
-                .list(user.getEmail())
-                .setMaxResults(10L)
-                .execute();
+        if(pageToken == null){
+            draftsResponse = gmail.users().drafts()
+                    .list(user.getEmail())
+                    .setMaxResults(10L)
+                    .execute();
+        }else{
+            draftsResponse = gmail.users().drafts()
+                    .list(user.getEmail())
+                    .setPageToken(pageToken)
+                    .setMaxResults(10L)
+                    .execute();
+        }
+
+        Map<String, Object> result = new HashMap<>();
 
         List<Draft> drafts = draftsResponse.getDrafts();
+        String nextPageToken = draftsResponse.getNextPageToken();
+
         List<DraftEmailResponseDTO> draftDTOs = new ArrayList<>();
 
         if (drafts != null) {
@@ -246,23 +259,45 @@ public class GmailService {
             }
         }
 
-        return draftDTOs;
+        result.put("emails", draftDTOs);
+        result.put("nextPageToken", nextPageToken);
+
+        return result;
     }
 
 
     // 내게 쓴 메일함은 라벨이 SENT, INBOX가 동시에 붙어있어서 user entity 조회
-    public List<SelfEmailResponseDTO> getSelfGmail(Authentication auth) throws IOException {
+    public Map<String, Object> getSelfGmail(String pageToken, Authentication auth) throws IOException {
         User user = getUser(auth);
         Gmail gmail = getGmailService(user);
-        List<Message> messages = gmail.users().messages().list(user.getEmail())
-                .setLabelIds(List.of("SENT", "INBOX"))
-                .setMaxResults(10L).execute().getMessages();
+
+        ListMessagesResponse messagesResponse;
+
+        if(pageToken == null){
+            messagesResponse = gmail.users().messages().list(user.getEmail())
+                    .setLabelIds(List.of("SENT", "INBOX"))
+                    .setMaxResults(10L).execute();
+        }else{
+            messagesResponse = gmail.users().messages().list(user.getEmail())
+                    .setLabelIds(List.of("SENT", "INBOX"))
+                    .setPageToken(pageToken)
+                    .setMaxResults(10L).execute();
+        }
+
+        String nextPageToken = messagesResponse.getNextPageToken();
+        List<Message> messages = messagesResponse.getMessages();
+
+        Map<String, Object> result = new HashMap<>();
 
         List<SelfEmailResponseDTO> emails = new ArrayList<>();
         for (Message msg : messages) {
             emails.add(mapToDTO(gmail, user.getEmail(), msg, SelfEmailResponseDTO.class));
         }
-        return emails;
+
+        result.put("emails", emails);
+        result.put("nextPageToken", nextPageToken);
+
+        return result;
     }
 
     // 파일 첨부 리소스 조회
@@ -274,21 +309,37 @@ public class GmailService {
     }
 
     // 특정 이메일 검색
-    public List<ImportantEmailResponseDTO> searchGmailsByUserEmail(SearchGmailsByUserEmailRequestDTO request, Authentication auth) throws IOException {
+    public Map<String, Object> searchGmailsByUserEmail(SearchGmailsByUserEmailRequestDTO request, String pageToken, Authentication auth) throws IOException {
         User user = getUser(auth);
         Gmail gmail = getGmailService(user);
+        ListMessagesResponse messagesResponse;
 
         String query = String.format("{from:%s is:inbox} OR {to:%s is:sent}",
                 request.getUserEmail(), request.getUserEmail());
 
-        List<Message> messages = gmail.users().messages().list(user.getEmail())
-                .setQ(query)
-                .setMaxResults(10L).execute().getMessages();
-
-        List<ImportantEmailResponseDTO> result = new ArrayList<>();
-        for (Message msg : messages) {
-            result.add(mapToDTO(gmail, user.getEmail(), msg, ImportantEmailResponseDTO.class));
+        if(pageToken == null){
+            messagesResponse = gmail.users().messages().list(user.getEmail())
+                    .setQ(query)
+                    .setMaxResults(10L).execute();
+        }else{
+            messagesResponse = gmail.users().messages().list(user.getEmail())
+                    .setQ(query)
+                    .setPageToken(pageToken)
+                    .setMaxResults(10L).execute();
         }
+
+        String nextPageToken = messagesResponse.getNextPageToken();
+        List<Message> messages = messagesResponse.getMessages();
+
+        List<ImportantEmailResponseDTO> emails = new ArrayList<>();
+        for (Message msg : messages) {
+            emails.add(mapToDTO(gmail, user.getEmail(), msg, ImportantEmailResponseDTO.class));
+        }
+
+        Map<String, Object> result = new HashMap<>();
+
+        result.put("emails", emails);
+        result.put("nextPageToken", nextPageToken);
 
         return result;
     }
@@ -316,12 +367,26 @@ public class GmailService {
      * @param <T>
      * @throws IOException
      */
-    private <T> List<T> getEmailsByLabel(Authentication auth, String label, Class<T> dtoClass) throws IOException {
+    private <T> Map<String, Object> getEmailsByLabel(String pageToken, Authentication auth, String label, Class<T> dtoClass) throws IOException {
         User user = getUser(auth);
         Gmail gmail = getGmailService(user);
-        List<Message> messages = gmail.users().messages().list(user.getEmail())
-                .setLabelIds(List.of(label))
-                .setMaxResults(10L).execute().getMessages();
+        ListMessagesResponse messagesResponse;
+
+        if(pageToken == null){
+            messagesResponse = gmail.users().messages().list(user.getEmail())
+                    .setLabelIds(List.of(label))
+                    .setMaxResults(10L).execute();
+        }else{
+            messagesResponse = gmail.users().messages().list(user.getEmail())
+                    .setPageToken(pageToken)
+                    .setLabelIds(List.of(label))
+                    .setMaxResults(10L).execute();
+        }
+
+        String nextPageToken = messagesResponse.getNextPageToken();
+        List<Message> messages = messagesResponse.getMessages();
+
+        Map<String, Object> result = new HashMap<>();
 
         List<T> emailDTOs = new ArrayList<>();
         if (messages != null) {
@@ -329,7 +394,10 @@ public class GmailService {
                 emailDTOs.add(mapToDTO(gmail, user.getEmail(), msg, dtoClass));
             }
         }
-        return emailDTOs;
+
+        result.put("emails", emailDTOs);
+        result.put("nextPageToken", nextPageToken);
+        return result;
     }
 
     // Message to DTO 변환

--- a/src/main/java/com/example/capstoneback/Service/UserService.java
+++ b/src/main/java/com/example/capstoneback/Service/UserService.java
@@ -27,7 +27,7 @@ public class UserService {
         User user = getUserFromHeaderToken(request);
 
         //유저 정보 업데이트
-        user.updateStudentInfo(studentInfo.getSchoolName() ,studentInfo.getStudentDepartment(), studentInfo.getStudentNum());
+        user.updateStudentInfo(studentInfo.getSchoolName() ,studentInfo.getStudentDepartment(), studentInfo.getStudentNum(), studentInfo.getStudentName());
         userRepository.save(user);
     }
 


### PR DESCRIPTION
## 구현 및 수정사항
1. 메일 내용 파싱 과정 수정은 진행하지 않음
2. 메일 수신 API 요청 파라미터에 pageToken 추가 및 응답에도 nextPageToken 항목 추가
3. 학생 정보 입력 항목에 studentName 추가