### PR TITLE
[Fix] 메일 내용 파싱 과정 수정

### DIFF
--- a/src/main/java/com/example/capstoneback/DTO/DraftEmailResponseDTO.java
+++ b/src/main/java/com/example/capstoneback/DTO/DraftEmailResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.capstoneback.DTO;
 
+import com.google.api.services.gmail.model.MessagePart;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,14 +13,14 @@ public class DraftEmailResponseDTO {
     private String id;
     private String draftId;
     private String title;
-    private String content;
+    private MessagePart content;
     private String receiver;
     private LocalDateTime createdAt;
     private Boolean isImportant;
     private List<HashMap<String, String>> fileNameList;
 
     @Builder
-    public DraftEmailResponseDTO(String id, String draftId, String title, String content, String receiver, LocalDateTime createdAt, Boolean isImportant, List<HashMap<String, String>> fileNameList) {
+    public DraftEmailResponseDTO(String id, String draftId, String title, MessagePart content, String receiver, LocalDateTime createdAt, Boolean isImportant, List<HashMap<String, String>> fileNameList) {
         this.id = id;
         this.draftId = draftId;
         this.title = title;

--- a/src/main/java/com/example/capstoneback/DTO/ImportantEmailResponseDTO.java
+++ b/src/main/java/com/example/capstoneback/DTO/ImportantEmailResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.capstoneback.DTO;
 
+import com.google.api.services.gmail.model.MessagePart;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,7 +12,7 @@ import java.util.List;
 public class ImportantEmailResponseDTO {
     private String id;
     private String title;
-    private String content;
+    private MessagePart content;
     private String sender;
     private String receiver;
     private LocalDateTime receiveAt;
@@ -19,7 +20,7 @@ public class ImportantEmailResponseDTO {
     private List<HashMap<String, String>> fileNameList;
 
     @Builder
-    public ImportantEmailResponseDTO(String id, String title, String content, String sender, String receiver, LocalDateTime receiveAt, LocalDateTime sendAt, boolean isImportant, List<HashMap<String, String>> fileNameList) {
+    public ImportantEmailResponseDTO(String id, String title, MessagePart content, String sender, String receiver, LocalDateTime receiveAt, LocalDateTime sendAt, boolean isImportant, List<HashMap<String, String>> fileNameList) {
         this.id = id;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/example/capstoneback/DTO/ReceivedEmailResponseDTO.java
+++ b/src/main/java/com/example/capstoneback/DTO/ReceivedEmailResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.capstoneback.DTO;
 
+import com.google.api.services.gmail.model.MessagePart;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,14 +12,14 @@ import java.util.List;
 public class ReceivedEmailResponseDTO {
     private String id;
     private String title;
-    private String content;
+    private MessagePart content;
     private String sender;
     private LocalDateTime receiveAt;
     private Boolean isImportant;
     private List<HashMap<String, String>> fileNameList;
 
     @Builder
-    public ReceivedEmailResponseDTO(String id, String title, String content, String sender, LocalDateTime receiveAt, Boolean isImportant, List<HashMap<String, String>> fileNameList) {
+    public ReceivedEmailResponseDTO(String id, String title, MessagePart content, String sender, LocalDateTime receiveAt, Boolean isImportant, List<HashMap<String, String>> fileNameList) {
         this.id = id;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/example/capstoneback/DTO/SelfEmailResponseDTO.java
+++ b/src/main/java/com/example/capstoneback/DTO/SelfEmailResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.capstoneback.DTO;
 
+import com.google.api.services.gmail.model.MessagePart;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,13 +12,13 @@ import java.util.List;
 public class SelfEmailResponseDTO {
     private String id;
     private String title;
-    private String content;
+    private MessagePart content;
     private LocalDateTime sendAt;
     private Boolean isImportant;
     private List<HashMap<String, String>> fileNameList;
 
     @Builder
-    public SelfEmailResponseDTO(String id, String title, String content, LocalDateTime sendAt, Boolean isImportant, List<HashMap<String, String>> fileNameList) {
+    public SelfEmailResponseDTO(String id, String title, MessagePart content, LocalDateTime sendAt, Boolean isImportant, List<HashMap<String, String>> fileNameList) {
         this.id = id;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/example/capstoneback/DTO/SentEmailResponseDTO.java
+++ b/src/main/java/com/example/capstoneback/DTO/SentEmailResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.capstoneback.DTO;
 
+import com.google.api.services.gmail.model.MessagePart;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,14 +12,14 @@ import java.util.List;
 public class SentEmailResponseDTO {
     private String id;
     private String title;
-    private String content;
+    private MessagePart content;
     private String receiver;
     private LocalDateTime sendAt;
     private Boolean isImportant;
     private List<HashMap<String, String>> fileNameList;
 
     @Builder
-    public SentEmailResponseDTO(String id, String title, String content, String receiver, LocalDateTime sendAt, Boolean isImportant, List<HashMap<String, String>> fileNameList) {
+    public SentEmailResponseDTO(String id, String title, MessagePart content, String receiver, LocalDateTime sendAt, Boolean isImportant, List<HashMap<String, String>> fileNameList) {
         this.id = id;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/example/capstoneback/DTO/SpamEmailResponseDTO.java
+++ b/src/main/java/com/example/capstoneback/DTO/SpamEmailResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.capstoneback.DTO;
 
+import com.google.api.services.gmail.model.MessagePart;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,14 +12,14 @@ import java.util.List;
 public class SpamEmailResponseDTO {
     private String id;
     private String title;
-    private String content;
+    private MessagePart content;
     private String sender;
     private LocalDateTime receiveAt;
     private Boolean isImportant;
     private List<HashMap<String, String>> fileNameList;
 
     @Builder
-    public SpamEmailResponseDTO(String id, String title, String content, String sender, LocalDateTime receiveAt, Boolean isImportant, List<HashMap<String, String>> fileNameList) {
+    public SpamEmailResponseDTO(String id, String title, MessagePart content, String sender, LocalDateTime receiveAt, Boolean isImportant, List<HashMap<String, String>> fileNameList) {
         this.id = id;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/example/capstoneback/Error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/capstoneback/Error/GlobalExceptionHandler.java
@@ -100,4 +100,12 @@ public class GlobalExceptionHandler { // 전역 에러 처리 클래스
         errorResponse.put("message", e.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
+
+    // 사용자의 google oauth2 access token이 만료되었을 때 발생하는 에러 처리
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalStateException(IllegalStateException e) {
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("message", e.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/example/capstoneback/Service/GmailService.java
+++ b/src/main/java/com/example/capstoneback/Service/GmailService.java
@@ -248,7 +248,7 @@ public class GmailService {
                         .draftId(draftId)
                         .id(message.getId())
                         .title(subject)
-                        .content(message.getSnippet())
+                        .content(message.getPayload())
                         .receiver(receiver)
                         .createdAt(createdAt)
                         .isImportant(message.getLabelIds().contains("STARRED"))
@@ -417,19 +417,24 @@ public class GmailService {
 
         List<HashMap<String, String>> attachments = getAttachments(detail);
 
-        // 발신자 메일
+        // 받은 메일
+
         if (dtoClass == ReceivedEmailResponseDTO.class) {
             return dtoClass.cast(ReceivedEmailResponseDTO.builder()
-                    .id(message.getId()).title(headers.get("Subject"))
-                    .sender(headers.get("From")).content(detail.getSnippet())
+                    .id(message.getId())
+                    .title(headers.get("Subject"))
+                    .sender(headers.get("From"))
+                    .content(detail.getPayload())
                     .receiveAt(date).isImportant(detail.getLabelIds().contains("STARRED"))
                     .fileNameList(attachments).build());
         }
-        // 수신자 메일
+        // 보낸 메일
         if (dtoClass == SentEmailResponseDTO.class) {
             return dtoClass.cast(SentEmailResponseDTO.builder()
-                    .id(message.getId()).title(headers.get("Subject"))
-                    .receiver(headers.get("To")).content(detail.getSnippet())
+                    .id(message.getId())
+                    .title(headers.get("Subject"))
+                    .receiver(headers.get("To"))
+                    .content(detail.getPayload())
                     .sendAt(date).isImportant(detail.getLabelIds().contains("STARRED"))
                     .fileNameList(attachments).build());
         }
@@ -437,33 +442,42 @@ public class GmailService {
         // 임시 메일
         if (dtoClass == DraftEmailResponseDTO.class) {
             return dtoClass.cast(DraftEmailResponseDTO.builder()
-                    .id(message.getId()).title(headers.get("Subject"))
-                    .receiver(headers.get("To")).content(detail.getSnippet())
+                    .id(message.getId())
+                    .title(headers.get("Subject"))
+                    .receiver(headers.get("To"))
+                    .content(detail.getPayload())
                     .createdAt(date).isImportant(detail.getLabelIds().contains("STARRED"))
                     .fileNameList(attachments).build());
         }
         // 중요 메일
         if (dtoClass == ImportantEmailResponseDTO.class) {
             return dtoClass.cast(ImportantEmailResponseDTO.builder()
-                    .id(message.getId()).title(headers.get("Subject"))
-                    .sender(headers.get("From")).receiver(headers.get("To"))
+                    .id(message.getId())
+                    .title(headers.get("Subject"))
+                    .sender(headers.get("From"))
+                    .receiver(headers.get("To"))
                     .sendAt(detail.getLabelIds().contains("SENT") ? date : null)
                     .receiveAt(detail.getLabelIds().contains("INBOX") ? date : null)
-                    .content(detail.getSnippet()).fileNameList(attachments).build());
+                    .content(detail.getPayload())
+                    .build());
         }
-        // 내게쓰기 메일
+        // 내게 쓴 메일
         if (dtoClass == SelfEmailResponseDTO.class) {
             return dtoClass.cast(SelfEmailResponseDTO.builder()
-                    .id(message.getId()).title(headers.get("Subject"))
-                    .content(detail.getSnippet()).sendAt(date)
+                    .id(message.getId())
+                    .title(headers.get("Subject"))
+                    .content(detail.getPayload())
+                    .sendAt(date)
                     .isImportant(detail.getLabelIds().contains("STARRED"))
                     .fileNameList(attachments).build());
         }
         // 스팸 메일
         if (dtoClass == SpamEmailResponseDTO.class) {
             return dtoClass.cast(SpamEmailResponseDTO.builder()
-                    .id(message.getId()).title(headers.get("Subject"))
-                    .sender(headers.get("From")).content(detail.getSnippet())
+                    .id(message.getId())
+                    .title(headers.get("Subject"))
+                    .sender(headers.get("From"))
+                    .content(detail.getPayload())
                     .receiveAt(date).isImportant(detail.getLabelIds().contains("STARRED"))
                     .fileNameList(attachments).build());
         }


### PR DESCRIPTION
## 구현 및 수정사항
1. 메일 조회 API 에서 content 내용 파싱 과정 수정 - 기존 String 타입에서 Object 타입으로 변경
2. 메일 DTO content의 type을 MessagePart로 변경 