### PR TITLE
[Feat] 메일 전달 API

### DIFF
--- a/src/main/java/com/example/capstoneback/DTO/SentEmailResponseDTO.java
+++ b/src/main/java/com/example/capstoneback/DTO/SentEmailResponseDTO.java
@@ -14,16 +14,20 @@ public class SentEmailResponseDTO {
     private String title;
     private MessagePart content;
     private String receiver;
+    private String sender;
+    private String mailType;
     private LocalDateTime sendAt;
     private Boolean isImportant;
     private List<HashMap<String, String>> fileNameList;
 
     @Builder
-    public SentEmailResponseDTO(String id, String title, MessagePart content, String receiver, LocalDateTime sendAt, Boolean isImportant, List<HashMap<String, String>> fileNameList) {
+    public SentEmailResponseDTO(String id, String title, MessagePart content, String receiver, String sender, String mailType, LocalDateTime sendAt, Boolean isImportant, List<HashMap<String, String>> fileNameList) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.receiver = receiver;
+        this.sender = sender;
+        this.mailType = mailType;
         this.sendAt = sendAt;
         this.isImportant = isImportant;
         this.fileNameList = fileNameList;

--- a/src/main/java/com/example/capstoneback/Service/GmailService.java
+++ b/src/main/java/com/example/capstoneback/Service/GmailService.java
@@ -244,11 +244,22 @@ public class GmailService {
         // 첨부파일 파싱
         List<HashMap<String, String>> attachments = getAttachments(message);
 
+        String mailType;
+        String userEmail = user.getEmail();
+
+        if(headers.get("To").contains(userEmail)){
+            mailType = "received";
+        }else{
+            mailType = "sent";
+        }
+
         // DTO 생성 및 반환
         return SentEmailResponseDTO.builder()
                 .id(message.getId())
                 .title(headers.get("Subject"))
                 .receiver(headers.get("To"))
+                .sender(headers.get("From"))
+                .mailType(mailType)
                 .content(message.getPayload())
                 .sendAt(date)
                 .isImportant(message.getLabelIds().contains("STARRED"))


### PR DESCRIPTION
## 구현 및 수정사항
1. 메일 전달 API는 구현하지 않음. 기존 발신 API 활용
2. 상세 메일 조회 API에 sender와 mailType 정보 추가